### PR TITLE
Adds a simple Python framework to express schedulers

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -51,3 +51,12 @@ MP-QUIC
 Datagram
 MP-DCCP
 reinjection
+reinjections
+fig-strict-prio
+fig-delay-threshold
+fig-simple-low-rtt
+i.e.
+srtt
+cc_state
+slow_start
+congestion_avoidance

--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -53,6 +53,7 @@ informative:
   RFC2119:
   RFC8174:
   RFC6356:
+  RFC6298:
   I-D.tuexen-tsvwg-sctp-multipath:
   I-D.deconinck-quic-multipath:
   I-D.amend-tsvwg-multipath-dccp:
@@ -295,6 +296,21 @@ In Multipath TCP, this is only partially possible. The subflow level
 acknowledgements must be sent on the subflow where the data was received while
 the data-level acknowledgements can be sent over any subflow.
 
+This document uses the Python language to represent multipath schedulers. A
+multipath scheduler is represented as a Python function. This function takes the
+length of the next packet to schedule as argument and returns the path on which
+it will be send. A path is represented as a Python class with the following
+attributes:
+
+ - srtt: The smoothed RTT of the path {{RFC6298}}.
+ - cc_state: The state of the congestion controller, i.e. either slow_start,
+   congestion_avoidance or recovery.
+ - blocked(l): A function indicating whether a packet of length l would be
+   rejected by the congestion controller.
+
+The schedulers presented can be executed in a simulator {{TODO}} implementing
+the abstract multipath protocol presented in {{abstract}}. It can be used to
+simulate a file transfer between a client and a server over multiple paths.
 
 ## Round-Robin
 
@@ -305,19 +321,19 @@ Multipath TCP {{ACMCS14}} indicate that it does not provide good performance.
 This packet scheduler uses one additional state at the connection level:
 last_path. This stores the identifier of the last path that was used to send a
 packet. We assume that the paths are identified by an integer. The scheduler is
-defined by the pseudocode shown in {{fig-rr}}.
+defined by the code shown in {{fig-rr}}.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class RoundRobin(Scheduler):
+    """ Chooses an available path in a round-robin manner between two paths. """
+    last_path: Optional[Path] = None
 
-Packet Arrival:  # data packet of length l
-begin:
-  last_path++  # select next path
-  if(not_blocked(path[last_path])):
-        send packet over last_path
-  else:
-        goto begin: # try next path
-
+    def schedule(self, packet_len: int):
+        for p in self.paths:
+            if p != self.last_path and not p.blocked(packet_len):
+                self.last_path = p
+                return p
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {: #fig-rr title="A simple Round Robin scheduler"}
 
@@ -328,9 +344,33 @@ window is open.
 
 ## Strict Priority
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class StrictPriority(Scheduler):
+    """ Chooses the first available path in the given order of paths. """
+
+    def schedule(self, packet_len: int):
+        for p in self.paths:
+            if not p.blocked(packet_len):
+                return p
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{: #fig-strict-prio title="A simple Strict Priority scheduler"}
+
 [comment]: # (OB: Path 0 has a higher priority than path one, with congestion window)
 
-## Delay threshold
+## Delay Threshold
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@dataclass
+class DelayThreshold(Scheduler):
+    """ Chooses the first available path below a certain delay threshold. """
+    threshold: float
+
+    def schedule(self, packet_len: int):
+        for p in self.paths:
+            if p.srtt < self.threshold and not p.blocked(packet_len):
+                return p
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{: #fig-delay-threshold title="A simple Delay Threshold scheduler"}
 
 [comment]: # (OB: Path 0 has a higher priority than path one, path one is used if packets has been delayed by more than threshold in transport entity)
 
@@ -353,6 +393,21 @@ satisfied:
 
 Among all the eligible paths, the scheduler will choose the path with the
 lowest RTT and transmit the segment with the new data on that path.
+{{fig-simple-low-rtt}} illustrates a simple lowest RTT scheduler which does not
+include fast reinjections.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class LowestRTTFirst(Scheduler):
+    """ Chooses the first available path with the lowest RTT. """
+
+    def schedule(self, packet_len: int):
+        # Sort paths by increasing SRTT
+        for p in sorted(self.paths, key=lambda path: path.srtt):
+            if not p.blocked(packet_len) \
+               and p.cc_state != 'recovery':
+                return p
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{: #fig-simple-low-rtt title="A simple Lowest RTT First scheduler"}
 
 To handle head-of-line blocking situations when the paths have a large delay
 difference the scheduler uses a strategy of opportunistic retransmission and
@@ -374,6 +429,7 @@ This mechanism is called penalization and is achieved by dividing the congestion
 window by 2.
 
 [comment]: # (CP: pseudocode)
+[comment]: # (MP: The simulator currently lacks rtx, rcv_wnd and snd_wnd concepts)
 
 
 ## Out-of-order transmission for in-order arrival 

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020, Maxime Piraux
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+"""
+This module implements a simulator for an abstract multipath transport protocol.
+This protocol transfers a file over several paths using a custom function.
+Complex multipath topologies can be expressed and simulated, as illustrated at
+the end of this module.
+"""
+
+from builtins import NotImplementedError
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Union, Tuple, Optional, Dict
+
+
+class PacketType(Enum):
+    DATA = 1
+    ACK = 2
+    RTX = 3
+    FIN = 4
+
+
+@dataclass
+class Packet:
+    length: int = 0
+    type: PacketType = PacketType.DATA
+    seq_number: int = 0
+
+    def __hash__(self) -> int:
+        return hash((self.seq_number, self.type, self.length))
+
+    def log_str(self) -> str:
+        names = {
+            PacketType.DATA: 'DATA',
+            PacketType.ACK: 'ACK',
+            PacketType.RTX: 'RTX',
+            PacketType.FIN: 'FIN',
+        }
+
+        if self.type == PacketType.DATA or self.type == PacketType.RTX:
+            return f'{names[self.type]}[{self.seq_number}, {self.seq_number+self.length}]'
+        elif self.type == PacketType.ACK:
+            return f'{names[self.type]}[{self.packet_acknowledged.log_str()}]'
+        elif self.type == PacketType.FIN:
+            return f'{names[self.type]}[{self.seq_number}]'
+
+        return 'UNKNOWN[]'
+
+
+@dataclass
+class Link:
+    """ A link that can queue up 1.5*BDP and paces packets when dequeuing them. """
+    bandwidth: int  # Bps
+    delay: float  # s
+    mtu: int  # bytes
+    max_queue_size: int = field(init=False)  # bytes
+    _next_dequeue_slot: float = field(init=False, default=0)  # s
+    _pacing_time: float = field(init=False)  # s
+    _queue: List[Tuple[Packet, float]] = field(init=False, default_factory=list)
+    _queue_size: int = 0
+
+    def __post_init__(self):
+        self.max_queue_size = int(self.bandwidth * 2 * self.delay * 1.5)
+        self._pacing_time = 1 / int(self.bandwidth / self.mtu)
+
+    def next_free_slot_time(self, time: float) -> float:
+        if not self._queue:
+            return time
+        p, queuing_time = self._queue[0]
+        return max(queuing_time + self.delay, time)
+
+    def enqueue(self, p: Packet, time: float) -> Union[bool, float]:
+        if p.length > self.mtu:
+            return float('inf')
+        if self._queue_size + p.length <= self.max_queue_size:
+            self._queue.append((p, time))
+            self._queue_size += p.length
+            return True
+        return self.next_free_slot_time(time)
+
+    def dequeue(self, time: float) -> Union[Packet, float]:
+        """ Returns the next packet or the time at which the next packet may be dequeued. """
+        if not self._queue:
+            return time + self.delay
+        if time < self._next_dequeue_slot:
+            return self._next_dequeue_slot
+
+        p, queuing_time = self._queue[0]
+        if queuing_time + self.delay <= time:
+            self._queue = self._queue[1:]
+            self._queue_size -= p.length
+            self._next_dequeue_slot = time + (self._pacing_time if self._queue and self._queue[0][0].length > 0 else 0)
+            return p
+        return max(queuing_time + self.delay, time)
+
+
+@dataclass
+class Interface:
+    sending_link: Link
+    receiving_link: Link
+
+    def send(self, p: Packet, time: float) -> Union[bool, float]:
+        """ Returns whether the packet was accepted and the next time at which a packet may be accepted. """
+        return self.sending_link.enqueue(p, time)
+
+    def receive(self, time: float) -> Union[Packet, float]:
+        """ Returns the first packet received or the next time at which a packet may be received. """
+        return self.receiving_link.dequeue(time)
+
+
+class CCState(Enum):
+    slow_start = 'slow_start'
+    congestion_avoidance = 'congestion_avoidance'
+    recovery = 'recovery'
+
+
+class CongestionController:
+    state: CCState = CCState.slow_start
+
+    def blocked(self, packet_len: int) -> bool:
+        raise NotImplementedError
+
+    def packet_sent(self, p: Packet, time: float):
+        raise NotImplementedError
+
+    def packet_acknowledged(self, p: Packet, time: float):
+        raise NotImplementedError
+
+    def packet_dupack(self, time: float):
+        raise NotImplementedError
+
+    def packet_lost(self, p: Packet, time: float):
+        raise NotImplementedError
+
+
+@dataclass
+class NewReno(CongestionController):
+    mss: int  # bytes
+    bytes_in_flight: int = 0  # bytes
+    ssthresh: int = 1000_000_000  # bytes
+    cwin: int = 0  # bytes
+    dupacks: int = 0  # packets
+
+    def __post_init__(self):
+        self.cwin = self.mss
+
+    def blocked(self, packet_len: int) -> bool:
+        return packet_len > self.mss or self.bytes_in_flight + packet_len > self.cwin
+
+    def packet_sent(self, p: Packet, time: float):
+        self.bytes_in_flight += p.length
+
+    def packet_acknowledged(self, p: Packet, time: float):
+        self.dupacks = 0
+        self.bytes_in_flight = max(0, self.bytes_in_flight - p.length)
+        if self.cwin < self.ssthresh:
+            self.cwin += p.length
+            self.state = CCState.slow_start
+        else:
+            self.cwin += int(self.mss / (self.cwin // self.mss))
+            self.state = CCState.congestion_avoidance
+
+    def packet_dupack(self, time: float):
+        self.dupacks += 1
+        if self.dupacks >= 3:
+            self.cwin //= 2
+            self.ssthresh = self.cwin
+            self.state = CCState.recovery
+
+    def packet_lost(self, p: Packet, time: float):
+        self.ssthresh = min(2 * self.mss, self.cwin // 2)
+        self.cwin = self.mss
+        self.state = CCState.recovery
+
+
+@dataclass
+class Path:
+    name: str
+    interface: Interface
+    cc: CongestionController
+    # Attributes for scheduling
+    srtt: float = 0
+
+    # Private attributes
+    _send_times: Dict[Packet, float] = field(default_factory=dict)
+
+    def send(self, p: Packet, time: float) -> Union[bool, float]:
+        """ Returns whether the packet was accepted or the next time at which a packet may be accepted. """
+        p.sending_path = self
+        sent = self.interface.send(p, time)
+        if type(sent) is bool:
+            if sent:
+                self.cc.packet_sent(p, time)
+                self._send_times[p] = time
+            else:
+                pass  # TODO: Too big MTU
+        else:  # TODO: Packet loss always happen at sending time when the link is full, while ACKs arrive after 1 RTT
+            self.cc.packet_dupack(time)
+        return sent
+
+    def receive(self, time: float) -> Union[Packet, float]:
+        """ Returns the first packet received or the next time at which a packet may be received. """
+        received = self.interface.receive(time)
+        if type(received) is Packet and received.type == PacketType.ACK:
+            acked: Packet = received.packet_acknowledged
+            acked_path: Path = received.packet_acknowledged.sending_path
+            acked_path._packet_acknowledged(acked, time)
+        return received
+
+    def _packet_acknowledged(self, packet: Packet, time: float):
+        self.cc.packet_acknowledged(packet, time)
+        if packet not in self._send_times:
+            return
+        sending_time = self._send_times[packet]
+        rtt_estimate = time - sending_time
+
+        if self.srtt is 0:
+            self.srtt = rtt_estimate
+        else:
+            self.srtt = ((1 / 8) * rtt_estimate) + ((7 / 8) * self.srtt)
+
+    def blocked(self, packet_len: int):
+        """ Returns whether the congestion controller accepts the sending of a packet of length packet_len. """
+        return self.cc.blocked(packet_len)
+
+    @property
+    def cc_state(self) -> CCState:
+        return self.cc.state
+
+
+@dataclass
+class Scheduler:
+    paths: List[Path]
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        raise NotImplementedError
+
+
+@dataclass
+class Host:
+    name: str
+    paths: List[Path]
+    scheduler: Scheduler
+    active: bool = field(init=False, default=True)
+
+    def run(self, time: float) -> float:
+        raise NotImplementedError
+
+    def compute_min_mss(self):
+        return min(p.interface.sending_link.mtu for p in self.paths)
+
+    def acknowledge(self, p: Packet, time: float):
+        ack = Packet(type=PacketType.ACK)  # TODO: ACKs are zero length
+        ack.packet_acknowledged = p
+        ret = self.send(ack, time)
+        if type(ret) is bool and ret:
+            print()
+
+    def send(self, p: Packet, time: float) -> Union[bool, float]:
+        path = self.scheduler.schedule(p.length)
+        if path:
+            ret = path.send(p, time)
+            if type(ret) is bool and ret:
+                print(f'{time:03.03f} {self.name}:{path.name} => {p.log_str()}', end=' ')
+            return ret
+        return time + 1  # We don't know when a path will become ready
+
+    def receive(self, time: float) -> Union[Packet, float]:
+        next_time = float('inf')
+        for p in self.paths:
+            rcvd = p.receive(time)
+            if type(rcvd) is Packet:
+                print(f'{time:.03f} {self.name}:{p.name} <= {rcvd.log_str()}', end=' ')
+                return rcvd
+            elif type(rcvd) is float:
+                next_time = min(rcvd, next_time)
+
+        return next_time
+
+
+@dataclass
+class Client(Host):
+    offset: int = 0
+    blocks: List[Tuple[int, int]] = field(default_factory=list)
+    fin_offset: int = 0
+
+    def run(self, time: float) -> float:
+        rcvd = self.receive(time)
+        if type(rcvd) is Packet:
+            if rcvd.type != PacketType.ACK:
+                if rcvd.seq_number < self.offset:
+                    print('Spurious retransmit')
+                elif rcvd.seq_number > self.offset:
+                    print('Out-of-order packet')
+                    self.blocks.append((rcvd.seq_number, rcvd.length))
+                    self.blocks.sort(key=lambda t: t[0])
+                else:
+                    self.offset += rcvd.length
+                    for start, length in self.blocks[:]:
+                        if self.offset == start:
+                            self.offset += length
+                            self.blocks = self.blocks[1:]
+                        else:
+                            break
+                    print()
+                self.acknowledge(rcvd, time)
+                if rcvd.type == PacketType.FIN:
+                    self.fin_offset = rcvd.seq_number
+            else:
+                print()
+            if self.offset == self.fin_offset:
+                return float('inf')
+            return self.run(time)
+        return max(rcvd, time)
+
+
+@dataclass
+class Server(Host):
+    file_size: int  # bytes
+    offset: int = 0  # bytes
+    min_mss: int = field(init=False)
+    fin_sent: bool = field(init=False)
+
+    def __post_init__(self):
+        self.min_mss = self.compute_min_mss()
+        self.fin_sent = False
+
+    def run(self, time: float) -> float:
+        rcvd = self.receive(time)
+        while type(rcvd) is Packet:
+            print()
+            if rcvd.type != PacketType.ACK:
+                self.acknowledge(rcvd, time)
+            elif rcvd.packet_acknowledged.type == PacketType.FIN:
+                return float('inf')  # FIN ACK received, mark the simulation as complete
+            rcvd = self.receive(time)
+
+        next_time = rcvd
+
+        if self.offset < self.file_size:  # Is there data to send ?
+            packet_len = min(self.file_size, self.min_mss)
+            p = Packet(length=packet_len, type=PacketType.DATA, seq_number=self.offset)
+            ret = self.send(p, time)
+            if type(ret) is bool:
+                if ret:
+                    self.offset += packet_len
+                    next_time = time
+                    print()
+                else:
+                    next_time = time + 1
+            else:
+                next_time = min(next_time, ret)
+        elif not self.fin_sent:  # Was the FIN sent ?
+            ret = self.send(Packet(length=0, type=PacketType.FIN, seq_number=self.file_size), time)
+            self.fin_sent = ret is True
+            if type(ret) is float:
+                next_time = min(next_time, ret)
+            print()
+
+        return max(next_time, time)
+
+
+@dataclass
+class Simulator:
+    hosts: List[Host]
+    time: float = 0
+
+    def run(self, until: float = float('inf')):
+        while self.time < until:
+            next_time = float('inf')
+            for h in self.hosts:
+                if not h.active:
+                    continue
+                t = h.run(self.time)
+                if t == float('inf'):
+                    print(h.name, 'has finished')
+                    h.active = False
+                next_time = min(next_time, t)
+            self.time = next_time
+
+
+class RoundRobin(Scheduler):
+    """ Chooses an available path in a round-robin manner between two paths. """
+    last_path: Optional[Path] = None
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        for p in self.paths:
+            if p != self.last_path and not p.blocked(packet_len):
+                self.last_path = p
+                return p
+
+
+class StrictPriority(Scheduler):
+    """ Chooses the first available path in the given order of paths. """
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        for p in self.paths:
+            if not p.blocked(packet_len):
+                return p
+
+
+@dataclass
+class DelayThreshold(Scheduler):
+    """ Chooses the first available path below a certain delay threshold. """
+    threshold: float
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        for p in self.paths:
+            if p.srtt < self.threshold and not p.blocked(packet_len):
+                return p
+
+
+class LowestRTTFirst(Scheduler):
+    """ Chooses the first available path with the lowest RTT. """
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        # Sort paths by increasing SRTT
+        for p in sorted(self.paths, key=lambda path: path.srtt):
+            if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
+                return p
+
+
+if __name__ == "__main__":
+    MSS = 500
+
+    def make_link():
+        return Link(bandwidth=10_000, delay=0.05, mtu=MSS)  # 10Mbps link with 50ms one-way-delay and 500 bytes MTU
+
+
+    link_c1_s1 = make_link()
+    link_c2_s2 = make_link()
+    link_s1_c1 = make_link()
+    link_s2_c2 = make_link()
+
+    path_c1_s1 = Path(name='Path1', interface=Interface(sending_link=link_c1_s1, receiving_link=link_s1_c1), cc=NewReno(mss=MSS))
+    path_c2_s2 = Path(name='Path2', interface=Interface(sending_link=link_c2_s2, receiving_link=link_s2_c2), cc=NewReno(mss=MSS))
+    path_s1_c1 = Path(name='Path1', interface=Interface(sending_link=link_s1_c1, receiving_link=link_c1_s1), cc=NewReno(mss=MSS))
+    path_s2_c2 = Path(name='Path2', interface=Interface(sending_link=link_s2_c2, receiving_link=link_c2_s2), cc=NewReno(mss=MSS))
+
+    client_paths = [path_c1_s1, path_c2_s2]
+    server_paths = [path_s1_c1, path_s2_c2]
+
+    Simulator(hosts=[
+        Client(name='Client', paths=client_paths, scheduler=RoundRobin(paths=client_paths)),
+        Server(name='Server', paths=server_paths, scheduler=RoundRobin(paths=server_paths), file_size=10_000)
+    ]).run(until=60)

--- a/test_scheduler_simulator.py
+++ b/test_scheduler_simulator.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2020, Maxime Piraux
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import unittest
+
+from scheduler_simulator import Link, Packet, PacketType
+
+
+class TestLink(unittest.TestCase):
+    def test_mtu(self):
+        """ Tests that the link MTU is respected. """
+        l = Link(bandwidth=10_000, delay=1, mtu=2)
+        p1 = Packet(length=1, type=PacketType.DATA)
+        p2 = Packet(length=2, type=PacketType.DATA)
+        p3 = Packet(length=3, type=PacketType.DATA)
+
+        self.assertTrue(l.enqueue(p1, 0))
+        self.assertEqual(l.dequeue(1), p1)
+        self.assertTrue(l.enqueue(p2, 1))
+        self.assertEqual(l.dequeue(2), p2)
+        self.assertEqual(l.enqueue(p3, 2), float('inf'))
+        self.assertNotEqual(l.dequeue(2), p3)
+
+    def test_delay(self):
+        """ Tests that the link delay is correct. """
+        l = Link(bandwidth=10_000, delay=1, mtu=1)
+        p = Packet(length=1, type=PacketType.DATA)
+
+        self.assertTrue(l.enqueue(p, 0))
+        self.assertEqual(l.dequeue(0), 1)
+        self.assertEqual(l.dequeue(0.999999), 1)
+        self.assertEqual(l.dequeue(1), p)
+
+    def test_pacing(self):
+        """ Tests that the pacing is correct regarding the bandwidth and MTU. """
+        l = Link(bandwidth=10, delay=0.5, mtu=2)
+        p = Packet(length=1, type=PacketType.DATA)
+        p2 = Packet(length=1, type=PacketType.DATA)
+        p3 = Packet(length=2, type=PacketType.DATA)
+
+        self.assertTrue(l.enqueue(p, 0))
+        self.assertTrue(l.enqueue(p2, 0))
+        self.assertTrue(l.enqueue(p3, 0))
+        self.assertAlmostEqual(l.dequeue(0), 0.5)
+        self.assertIs(l.dequeue(0.5), p)
+        self.assertAlmostEqual(l.dequeue(0.5), 0.7)
+        self.assertAlmostEqual(l.dequeue(0.69999), 0.7)
+        self.assertIs(l.dequeue(0.7), p2)
+        self.assertAlmostEqual(l.dequeue(0.7), 0.9)
+        self.assertAlmostEqual(l.dequeue(0.89999), 0.9)
+        self.assertIs(l.dequeue(0.9), p3)
+
+    def test_bandwidth(self):
+        """ Tests that the bandwidth cannot be exceeded. """
+        l = Link(bandwidth=3, delay=1, mtu=1)
+
+        p1 = Packet(length=1, type=PacketType.DATA)
+        p2 = Packet(length=1, type=PacketType.DATA)
+        p3 = Packet(length=1, type=PacketType.DATA)
+        p4 = Packet(length=1, type=PacketType.DATA)
+
+        for p in [p1, p2, p3, p4]:
+            self.assertTrue(l.enqueue(p, 0))
+
+        self.assertEqual(l.dequeue(0), 1)
+
+        self.assertIs(l.dequeue(1), p1)
+        self.assertAlmostEqual(l.dequeue(4 / 3 - 0.000001), 4 / 3)
+        self.assertIs(l.dequeue(4 / 3), p2)
+        self.assertAlmostEqual(l.dequeue(5 / 3 - 0.000001), 5 / 3)
+        self.assertIs(l.dequeue(5 / 3), p3)
+        self.assertAlmostEqual(l.dequeue(1.999999), 2)
+        self.assertIs(l.dequeue(2), p4)
+
+    def test_full_link(self):
+        """ Tests that a full link drops exceeding packets instead of queueing them."""
+        l = Link(bandwidth=1, delay=1, mtu=1)
+
+        p1 = Packet(length=1, type=PacketType.DATA)
+        p2 = Packet(length=1, type=PacketType.DATA)
+        p3 = Packet(length=1, type=PacketType.DATA)
+        p4 = Packet(length=1, type=PacketType.DATA)
+
+        for p in [p1, p2, p3]:
+            self.assertTrue(l.enqueue(p, 0))
+
+        self.assertEqual(l.enqueue(p4, 0), 1)
+
+        self.assertIs(l.dequeue(1), p1)
+        self.assertAlmostEqual(l.dequeue(1.999999), 2)
+        self.assertIs(l.dequeue(2), p2)
+        self.assertAlmostEqual(l.dequeue(2.999999), 3)
+        self.assertIs(l.dequeue(3), p3)
+        self.assertAlmostEqual(l.dequeue(3), 4)
+        self.assertAlmostEqual(l.dequeue(4), 5)


### PR DESCRIPTION
This PR adds a simple Python framework to express schedulers. It also adds a simulator implementing parts ot the abstract multipath transport protocol defined in the drafts.
I implemented the Delay Threshold, Strict Priority and a simple Lowest RTT schedulers as well.
The simulator lacks some features described in the drafts, such as snd and rcv windows and rtx, but is flexible enough to add them later.

I believe the Python syntax is easy to read and unambiguous at the same time. The ability to run schedulers directly in a simple simulator is a nice plus IMO.