### PR TITLE
sched:rr: support more and less than 2 paths

### DIFF
--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -326,7 +326,7 @@ simulate a file transfer between a client and a server over multiple paths.
 ## Round-Robin
 
 We use the Round-Robin scheduler as a simple example to illustrate how a packet
-scheduler can be specified, but do not recommend its usage. Experiments with
+scheduler can be specified, but we do not recommend its usage. Experiments with
 Multipath TCP {{ACMCS14}} indicate that it does not provide good performance.
 
 This packet scheduler uses one additional state at the connection level:
@@ -337,12 +337,14 @@ defined by the code shown in {{fig-rr}}.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class RoundRobin(Scheduler):
-    """ Chooses an available path in a round-robin manner between two paths. """
+    """ Chooses an available path in a round-robin manner between multiple paths. """
     last_path: Optional[Path] = None
 
     def schedule(self, packet_len: int):
-        for p in self.paths:
-            if p != self.last_path and not p.blocked(packet_len):
+        next_idx = self.paths.index(self.last_path) + 1 if self.last_path in self.paths else 0
+        sorted_paths = self.paths[next_idx:] + self.paths[:next_idx]
+        for p in sorted_paths:
+            if not p.blocked(packet_len):
                 self.last_path = p
                 return p
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -395,12 +395,14 @@ class Simulator:
 
 
 class RoundRobin(Scheduler):
-    """ Chooses an available path in a round-robin manner between two paths. """
+    """ Chooses an available path in a round-robin manner between multiple paths. """
     last_path: Optional[Path] = None
 
     def schedule(self, packet_len: int) -> Optional[Path]:
-        for p in self.paths:
-            if p != self.last_path and not p.blocked(packet_len):
+        next_idx = self.paths.index(self.last_path) + 1 if self.last_path in self.paths else 0
+        sorted_paths = self.paths[next_idx:] + self.paths[:next_idx]
+        for p in sorted_paths:
+            if not p.blocked(packet_len):
                 self.last_path = p
                 return p
 


### PR DESCRIPTION
In the previous version, it was only designed for 2 paths. Modifications
are minor to support other numbers.

It increases the complexity so we might not want this but RR was the only one supporting only 2 paths, no less, no more.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>