### PR TITLE
sched:priority: add a 'priority' attribute

### DIFF
--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -357,16 +357,17 @@ window is open.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class StrictPriority(Scheduler):
-    """ Chooses the first available path in the given order of paths. """
+    """ Chooses the first available path in a priority list of paths. """
 
     def schedule(self, packet_len: int):
-        for p in self.paths:
+        for p in sorted(self.paths, key=lambda path: path.priority, reverse=True):
             if not p.blocked(packet_len):
                 return p
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {: #fig-strict-prio title="A simple Strict Priority scheduler"}
 
 [comment]: # (OB: Path 0 has a higher priority than path one, with congestion window)
+[comment]: # (MB: the paths are now sorted by priority to make it clearer)
 
 ## Delay Threshold
 

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -195,6 +195,7 @@ class Path:
     cc: CongestionController
     # Attributes for scheduling
     srtt: float = 0
+    priority: int = 10
 
     # Private attributes
     _send_times: Dict[Packet, float] = field(default_factory=dict)
@@ -406,10 +407,10 @@ class RoundRobin(Scheduler):
 
 
 class StrictPriority(Scheduler):
-    """ Chooses the first available path in the given order of paths. """
+    """ Chooses the first available path in a priority list of paths. """
 
     def schedule(self, packet_len: int) -> Optional[Path]:
-        for p in self.paths:
+        for p in sorted(self.paths, key=lambda path: path.priority, reverse=True):
             if not p.blocked(packet_len):
                 return p
 


### PR DESCRIPTION
To clearly show that we sort the list based on priorities, not just "a"
list.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>