### PR TITLE
simulator: fix Python warning

### DIFF
--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -229,7 +229,7 @@ class Path:
         sending_time = self._send_times[packet]
         rtt_estimate = time - sending_time
 
-        if self.srtt is 0:
+        if self.srtt == 0:
             self.srtt = rtt_estimate
         else:
             self.srtt = ((1 / 8) * rtt_estimate) + ((7 / 8) * self.srtt)


### PR DESCRIPTION
  scheduler_simulator.py:232: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if self.srtt is 0:

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>