### PR TITLE
new sched: Priority and Lowest RTT first

### DIFF
--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -432,7 +432,7 @@ This kind of protection can of course be added to other existing schedulers.
 [comment]: # (OB: Path 0 has a higher priority than path one, path one is used if packets has been delayed by more than threshold in transport entity)
 
 
-## Lowest round-trip-time first
+## Lowest Round-Trip-Time First
 
 
 The Lowest round-trip-time first scheduler's goal is to minimize latency for

--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -407,7 +407,7 @@ the help of the congestion control algorithm.
 [comment]: # (OB: Path 0 has a higher priority than path one, with congestion window)
 [comment]: # (MB: the paths are now sorted by priority to make it clearer)
 
-## Delay Threshold
+## Delay Threshold {#delay-threshold}
 
 The Delay Threshold scheduler selects the first available path with a smoothed
 round-trip-time below a certain threshold. The goal is to keep the RTT of the
@@ -432,7 +432,7 @@ This kind of protection can of course be added to other existing schedulers.
 [comment]: # (OB: Path 0 has a higher priority than path one, path one is used if packets has been delayed by more than threshold in transport entity)
 
 
-## Lowest Round-Trip-Time First
+## Lowest Round-Trip-Time First {#lowest-rtt}
 
 
 The Lowest round-trip-time first scheduler's goal is to minimize latency for
@@ -492,6 +492,57 @@ window by 2.
 [comment:] ## Out-of-order transmission for in-order arrival
 
 [comment]: # (MA: overload fastest path to match latency of slower path; avoids ideally re-ordering)
+
+
+## Combination of schedulers type: Priority and Lowest round-trip-time first
+
+Combining some types of schedulers can be a way to address some use cases. For
+example, a scheduler using the priority and the round-trip-time attributes can
+be used to give more priorities to some links having a lower cost (e.g. fixed
+vs. mobile accesses) while still being able to benefit from the advantages of
+the "Lowest RTT First" scheduler described in {{lowest-rtt}}. A prototype of
+this "hybrid" scheduler is shown in {{fig-priority-and-lowest-rtt-first}}.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class PriorityAndLowestRTTFirst(Scheduler):
+    """ Chooses the first available path with the highest priority and then the lowest RTT. """
+
+    def schedule(self, packet_len: int):
+        # Sort paths by ascending priority (2nd sort) and then ascending SRTT (1st sort)
+        paths = sorted(self.paths, key=lambda path: path.srtt)
+        paths = sorted(paths, key=lambda path: path.priority, reverse=True)
+        for p in sorted(self.paths, key=lambda path: path.srtt):
+            if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
+                return p
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{: #fig-priority-and-lowest-rtt-first title="A scheduler combining priority and RTT attributes"}
+
+Combining some properties can have new undesired effects. In the case presented
+here, paths with a higher priority but also a higher RTT can affect performances
+compared to a setup having a scheduler not looking at the priority but only the
+round-trip-time. If paths with a higher priority are used first whatever the
+network conditions are on these paths, it is normal to sacrifice the total
+bandwidth capacity but fully use the capacity of these links with a higher
+priority. If the paths with a lower priority are seen as extra capacity that can
+be used only when the other links are congested, it is fine if they are not
+fully used when the sender is limited by the global sending window of the
+multipath connection.
+
+For this kind of scheduler, it could be interesting to also associate the
+benefits associated to a "Delay Threshold" scheduler described in
+{{delay-threshold}}. This scheduler prevents being too impacted by links having
+a higher priority but a very high RTT while other paths, with a lower priority
+and a lower RTT, can be used. It is a matter of qualifying what is important:
+maximising the use of paths over reducing the latency and probably the total
+bandwidth as well if the sender and/or the receiver are limited by congestion
+windows.
+
+It is also important to note that the penalization mechanism described in the
+"Lowest round-trip-time first" scheduler in {{lowest-rtt}} also needs to take
+into account the priority. If the goal is to maximise the use of some links over
+ others, links with a higher priority cannot be penalized over the ones with a
+lower priority. The consequence of this would be that links with higher priority
+ are under used due to the penalisation.
 
 
 

--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -511,7 +511,7 @@ class PriorityAndLowestRTTFirst(Scheduler):
         # Sort paths by ascending priority (2nd sort) and then ascending SRTT (1st sort)
         paths = sorted(self.paths, key=lambda path: path.srtt)
         paths = sorted(paths, key=lambda path: path.priority, reverse=True)
-        for p in sorted(self.paths, key=lambda path: path.srtt):
+        for p in paths:
             if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
                 return p
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -552,4 +552,3 @@ ASCII figure
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {: #fig-ascii title="A simple figure"}
-

--- a/draft-schedulers.mkd
+++ b/draft-schedulers.mkd
@@ -458,7 +458,7 @@ class LowestRTTFirst(Scheduler):
     """ Chooses the first available path with the lowest RTT. """
 
     def schedule(self, packet_len: int):
-        # Sort paths by increasing SRTT
+        # Sort paths by ascending SRTT
         for p in sorted(self.paths, key=lambda path: path.srtt):
             if not p.blocked(packet_len) \
                and p.cc_state != 'recovery':

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -445,7 +445,7 @@ class LowestRTTFirst(Scheduler):
     """ Chooses the first available path with the lowest RTT. """
 
     def schedule(self, packet_len: int) -> Optional[Path]:
-        # Sort paths by increasing SRTT
+        # Sort paths by ascending SRTT
         for p in sorted(self.paths, key=lambda path: path.srtt):
             if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
                 return p

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -458,7 +458,7 @@ class PriorityAndLowestRTTFirst(Scheduler):
         # Sort paths by ascending priority (2nd sort) and then ascending SRTT (1st sort)
         paths = sorted(self.paths, key=lambda path: path.srtt)
         paths = sorted(paths, key=lambda path: path.priority, reverse=True)
-        for p in sorted(self.paths, key=lambda path: path.srtt):
+        for p in paths:
             if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
                 return p
 

--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -451,6 +451,18 @@ class LowestRTTFirst(Scheduler):
                 return p
 
 
+class PriorityAndLowestRTTFirst(Scheduler):
+    """ Chooses the first available path with the highest priority and then the lowest RTT. """
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        # Sort paths by ascending priority (2nd sort) and then ascending SRTT (1st sort)
+        paths = sorted(self.paths, key=lambda path: path.srtt)
+        paths = sorted(paths, key=lambda path: path.priority, reverse=True)
+        for p in sorted(self.paths, key=lambda path: path.srtt):
+            if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
+                return p
+
+
 if __name__ == "__main__":
     MSS = 500
 


### PR DESCRIPTION
This scheduler combines two attributes: priority and RTT. It looks like a good example because it shows the limits of combining attributes.

Note: there are two other small fixes prior that.