### PR TITLE
[WIP] new sched: backup scheduler

### DIFF
--- a/scheduler_simulator.py
+++ b/scheduler_simulator.py
@@ -196,6 +196,7 @@ class Path:
     # Attributes for scheduling
     srtt: float = 0
     priority: int = 10
+    backup: bool = False
 
     # Private attributes
     _send_times: Dict[Packet, float] = field(default_factory=dict)
@@ -448,6 +449,18 @@ class LowestRTTFirst(Scheduler):
         # Sort paths by increasing SRTT
         for p in sorted(self.paths, key=lambda path: path.srtt):
             if not p.blocked(packet_len) and p.cc.state is not CCState.recovery:
+                return p
+
+
+class Backup(Scheduler):
+    """ Chooses the first available non backup path if there are backup paths. """
+
+    def schedule(self, packet_len: int) -> Optional[Path]:
+        paths = [p for p in self.paths if not p.backup]
+        if not paths:
+            paths = self.paths # only backup paths or none
+        for p in self.paths:
+            if not p.blocked(packet_len):
                 return p
 
 


### PR DESCRIPTION
Similar to what we have in MPTCP.

I don't know if we want to describe this because in the abstract, we say
that we don't really want to talk about active/backup paths. I started
the code to describe a Backup Overflow scheduler but at the end, it made
more sense to me to describe a Priority And Lowest RTT First scheduler.

Anyway, I am putting that here just in case we want to describe an
active/backup scheduler: we push on backup paths only if there is no
active paths in the list.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>